### PR TITLE
Also allow nodes with millicore notation

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -267,13 +267,23 @@ func fit(pod *Pod) ([]Node, error) {
 	}
 
 	for _, node := range nodeList.Items {
-		cpu := node.Status.Allocatable["cpu"]
-		cpuFloat, err := strconv.ParseFloat(cpu, 32)
-		if err != nil {
-			return nil, err
+		var milliCores int
+		if strings.HasSuffix(node.Status.Allocatable["cpu"], "m") {
+			cpu := strings.TrimSuffix(node.Status.Allocatable["cpu"], "m")
+			milliCores, err = strconv.Atoi(cpu)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			cpu := node.Status.Allocatable["cpu"]
+			cpuFloat, err := strconv.ParseFloat(cpu, 32)
+			if err != nil {
+				return nil, err
+			}
+			milliCores = int(cpuFloat * 1000)
 		}
 
-		freeSpace := (int(cpuFloat*1000) - resourceUsage[node.Metadata.Name].CPU)
+		freeSpace := (milliCores - resourceUsage[node.Metadata.Name].CPU)
 		if freeSpace < spaceRequired {
 			m := fmt.Sprintf("fit failure on node (%s): Insufficient CPU", node.Metadata.Name)
 			fitFailures = append(fitFailures, m)


### PR DESCRIPTION
I got an error because the .status.allocatable.cpu field used the millicore notation in my setup. This fix accepts both.